### PR TITLE
[FEAT] 5 에러 핸들러 구현

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+export default {
+    preset: 'ts-jest',
+    testEnvironment: 'node',
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 export default {
     preset: 'ts-jest',
     testEnvironment: 'node',
+    modulePathIgnorePatterns: ["<rootDir>/dist/"]
 };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "main": "main.js",
   "type": "module",
   "scripts": {
-    "test": "npm run build:ts && tsc -p test/tsconfig.json && c8 node --test -r ts-node/register \"test/**/*.ts\"",
     "start": "npm run build:ts && dotenv -e .env -- node dist/main.js",
     "dev": "tsx watch src/main.ts",
     "run:ts": "tsx src/main.ts",
@@ -12,7 +11,8 @@
     "build:ts": "tsc",
     "clean": "rm -rf dist",
     "lint": "eslint \"src/**/*.{ts,tsx}\" --fix",
-    "format": "prettier --write \"src/**/*.{ts,tsx}\""
+    "format": "prettier --write \"src/**/*.{ts,tsx}\"",
+    "test": "jest --rootDir=src"
   },
   "author": "",
   "license": "ISC",
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@eslint/config-array": "^0.19.2",
     "@eslint/object-schema": "^2.1.6",
+    "@types/jest": "^29.5.14",
     "@types/node": "^22.13.10",
     "@types/pino": "^7.0.4",
     "@typescript-eslint/eslint-plugin": "^8.26.1",
@@ -48,8 +49,10 @@
     "fastify-tsconfig": "^3.0.0",
     "glob": "^11.0.1",
     "globals": "^16.0.0",
+    "jest": "^29.7.0",
     "prettier": "^3.5.3",
     "prisma": "^6.5.0",
+    "ts-jest": "^29.2.6",
     "tsx": "^4.19.3",
     "typescript": "^5.8.2"
   }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "clean": "rm -rf dist",
     "lint": "eslint \"src/**/*.{ts,tsx}\" --fix",
     "format": "prettier --write \"src/**/*.{ts,tsx}\"",
-    "test": "jest --rootDir=src"
+    "test": "jest",
+    "test:coverage": "jest --coverage"
   },
   "author": "",
   "license": "ISC",

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,7 +1,20 @@
-import { FastifyInstance } from 'fastify';
+import { FastifyError, FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 
 import routeV1 from './v1/index.js';
+import { STATUS } from './v1/constants/status.js';
 
 export default async function app(fastify: FastifyInstance) {
+  fastify.setErrorHandler((error: FastifyError, request: FastifyRequest, reply: FastifyReply) => {
+    fastify.log.info(error.statusCode);
+    fastify.log.info(error.code);
+    fastify.log.info(error.message);
+
+    const statusCode: number = error.statusCode || 500;
+    reply.code(statusCode).send({
+      "status": STATUS.ERROR,
+      "message": error.message,
+    });
+  });
+
   fastify.register(routeV1, { prefix: '/v1' });
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -11,8 +11,8 @@ export default async function app(fastify: FastifyInstance) {
 
     const statusCode: number = error.statusCode || 500;
     reply.code(statusCode).send({
-      "status": STATUS.ERROR,
-      "message": error.message,
+      status: STATUS.ERROR,
+      message: error.message,
     });
   });
 

--- a/src/v1/controllers/auth.controller.ts
+++ b/src/v1/controllers/auth.controller.ts
@@ -6,7 +6,6 @@ import {
   loginRequestSchema,
   loginResponseSchema,
   signupRequestSchema,
-  signupResponseSchema,
 } from '../schemas/auth.schema.js';
 
 export async function signupController(
@@ -17,9 +16,7 @@ export async function signupController(
 ) {
   try {
     const result = await signupService(request.body, request.log);
-    const validatedResponse = signupResponseSchema.parse(result);
-
-    reply.status(201).send(validatedResponse);
+    reply.status(201).send(result);
   } catch (error) {
     reply.status(400).send({ error });
   }
@@ -33,9 +30,7 @@ export async function loginController(
 ) {
   try {
     const result = await loginService(request.body, request.log);
-    const validatedResponse = loginResponseSchema.parse(result);
-
-    reply.status(200).send(validatedResponse);
+    reply.status(200).send(result);
   } catch (error) {
     reply.status(401).send({ error });
   }

--- a/src/v1/controllers/auth.controller.ts
+++ b/src/v1/controllers/auth.controller.ts
@@ -2,11 +2,7 @@ import { z } from 'zod';
 import { FastifyReply, FastifyRequest } from 'fastify';
 
 import { signupService, loginService } from '../services/auth.service.js';
-import {
-  loginRequestSchema,
-  loginResponseSchema,
-  signupRequestSchema,
-} from '../schemas/auth.schema.js';
+import { loginRequestSchema, signupRequestSchema } from '../schemas/auth.schema.js';
 
 export async function signupController(
   request: FastifyRequest<{

--- a/src/v1/controllers/users.controller.ts
+++ b/src/v1/controllers/users.controller.ts
@@ -1,12 +1,17 @@
 import { FastifyReply, FastifyRequest } from 'fastify';
 import { z } from 'zod';
 import { getUserParamsSchema } from '../schemas/user.schema.js';
+import { ForbiddenException } from '../exceptions/core.error.js';
 
 export async function findUserController(request: FastifyRequest<{
   Params: z.infer<typeof getUserParamsSchema>
 }>, reply: FastifyReply) {
-  const { id } = request.params;
+  const id = parseInt(request.params.id);
+
 
   request.log.info(`user id: ${id}`);
+  if (id === 1) {
+    throw new ForbiddenException("You can't access this user");
+  }
   reply.code(200).send('hello');
 }

--- a/src/v1/controllers/users.controller.ts
+++ b/src/v1/controllers/users.controller.ts
@@ -1,5 +1,12 @@
 import { FastifyReply, FastifyRequest } from 'fastify';
+import { z } from 'zod';
+import { getUserParamsSchema } from '../schemas/user.schema.js';
 
-export async function findUserController(request: FastifyRequest, reply: FastifyReply) {
+export async function findUserController(request: FastifyRequest<{
+  Params: z.infer<typeof getUserParamsSchema>
+}>, reply: FastifyReply) {
+  const { id } = request.params;
+
+  request.log.info(`user id: ${id}`);
   reply.code(200).send('hello');
 }

--- a/src/v1/controllers/users.controller.ts
+++ b/src/v1/controllers/users.controller.ts
@@ -1,13 +1,16 @@
 import { FastifyReply, FastifyRequest } from 'fastify';
 import { z } from 'zod';
+
 import { getUserParamsSchema } from '../schemas/user.schema.js';
 import { ForbiddenException } from '../exceptions/core.error.js';
 
-export async function findUserController(request: FastifyRequest<{
-  Params: z.infer<typeof getUserParamsSchema>
-}>, reply: FastifyReply) {
+export async function findUserController(
+  request: FastifyRequest<{
+    Params: z.infer<typeof getUserParamsSchema>;
+  }>,
+  reply: FastifyReply,
+) {
   const id = parseInt(request.params.id);
-
 
   request.log.info(`user id: ${id}`);
   if (id === 1) {

--- a/src/v1/exceptions/core.error.ts
+++ b/src/v1/exceptions/core.error.ts
@@ -1,0 +1,52 @@
+export class HttpException extends Error {
+    public readonly statusCode: number;
+  
+    constructor(statusCode: number, message: string) {
+      super(message);
+      this.name = new.target.name;
+      this.statusCode = statusCode;
+    }
+  }
+  
+export class BadRequestException extends HttpException {
+    constructor(message: string) {
+      super(400, message || 'Bad Request');
+    }
+  }
+
+export class UnAuthorizedException extends HttpException {
+    constructor(message: string) {
+      super(401, message || 'Unauthorized');
+    }
+  }
+
+export class ForbiddenException extends HttpException {
+    constructor(message: string) {
+      super(403, message || 'Forbidden');
+    }
+  }
+
+export class NotFoundException extends HttpException {
+    constructor(message: string) {
+      super(404, message || 'Not Found');
+    }
+  }
+
+export class ConflictException extends HttpException {
+    constructor(message: string) {
+      super(409, message || 'Conflict');
+    }
+  }
+
+export class InternalServerException extends HttpException {
+    constructor(message: string) {
+      super(500, message || 'Internal Server Error');
+    }
+  }
+
+export class NotImplementedException extends HttpException {
+    constructor(message: string) {
+      super(501, message || 'Not Implemented');
+    }
+  }
+

--- a/src/v1/exceptions/core.error.ts
+++ b/src/v1/exceptions/core.error.ts
@@ -1,52 +1,51 @@
 export class HttpException extends Error {
-    public readonly statusCode: number;
-  
-    constructor(statusCode: number, message: string) {
-      super(message);
-      this.name = new.target.name;
-      this.statusCode = statusCode;
-    }
+  public readonly statusCode: number;
+
+  constructor(statusCode: number, message: string) {
+    super(message);
+    this.name = new.target.name;
+    this.statusCode = statusCode;
   }
-  
+}
+
 export class BadRequestException extends HttpException {
-    constructor(message: string) {
-      super(400, message || 'Bad Request');
-    }
+  constructor(message: string) {
+    super(400, message || 'Bad Request');
   }
+}
 
 export class UnAuthorizedException extends HttpException {
-    constructor(message: string) {
-      super(401, message || 'Unauthorized');
-    }
+  constructor(message: string) {
+    super(401, message || 'Unauthorized');
   }
+}
 
 export class ForbiddenException extends HttpException {
-    constructor(message: string) {
-      super(403, message || 'Forbidden');
-    }
+  constructor(message: string) {
+    super(403, message || 'Forbidden');
   }
+}
 
 export class NotFoundException extends HttpException {
-    constructor(message: string) {
-      super(404, message || 'Not Found');
-    }
+  constructor(message: string) {
+    super(404, message || 'Not Found');
   }
+}
 
 export class ConflictException extends HttpException {
-    constructor(message: string) {
-      super(409, message || 'Conflict');
-    }
+  constructor(message: string) {
+    super(409, message || 'Conflict');
   }
+}
 
 export class InternalServerException extends HttpException {
-    constructor(message: string) {
-      super(500, message || 'Internal Server Error');
-    }
+  constructor(message: string) {
+    super(500, message || 'Internal Server Error');
   }
+}
 
 export class NotImplementedException extends HttpException {
-    constructor(message: string) {
-      super(501, message || 'Not Implemented');
-    }
+  constructor(message: string) {
+    super(501, message || 'Not Implemented');
   }
-
+}

--- a/src/v1/routes/auth.route.ts
+++ b/src/v1/routes/auth.route.ts
@@ -1,11 +1,39 @@
 import { FastifyInstance } from 'fastify';
 
 import { loginController, signupController } from '../controllers/auth.controller.js';
+import {
+  loginRequestSchema,
+  loginResponseSchema,
+  signupRequestSchema,
+  signupResponseSchema,
+} from '../schemas/auth.schema.js';
 
 export default async function authRoutes(fastify: FastifyInstance) {
   // Signup route
-  fastify.post('/', signupController);
+  fastify.post(
+    '/',
+    {
+      schema: {
+        body: signupRequestSchema,
+        response: {
+          201: signupResponseSchema,
+        },
+      },
+    },
+    signupController,
+  );
 
   // Login route
-  fastify.post('/login', loginController);
+  fastify.post(
+    '/login',
+    {
+      schema: {
+        body: loginRequestSchema,
+        response: {
+          201: loginResponseSchema,
+        },
+      },
+    },
+    loginController,
+  );
 }

--- a/src/v1/routes/users.route.ts
+++ b/src/v1/routes/users.route.ts
@@ -4,9 +4,13 @@ import { findUserController } from '../controllers/users.controller.js';
 import { getUserParamsSchema } from '../schemas/user.schema.js';
 
 export default async function usersRoutes(fastify: FastifyInstance) {
-  fastify.get('/:id', {
-    schema: {
-      params: getUserParamsSchema
-    }
-  }, findUserController);
+  fastify.get(
+    '/:id',
+    {
+      schema: {
+        params: getUserParamsSchema,
+      },
+    },
+    findUserController,
+  );
 }

--- a/src/v1/routes/users.route.ts
+++ b/src/v1/routes/users.route.ts
@@ -1,7 +1,12 @@
 import { FastifyInstance } from 'fastify';
 
 import { findUserController } from '../controllers/users.controller.js';
+import { getUserParamsSchema } from '../schemas/user.schema.js';
 
 export default async function usersRoutes(fastify: FastifyInstance) {
-  fastify.get('/', findUserController);
+  fastify.get('/:id', {
+    schema: {
+      params: getUserParamsSchema
+    }
+  }, findUserController);
 }

--- a/src/v1/schemas/auth.schema.ts
+++ b/src/v1/schemas/auth.schema.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 import { createResponseSchema } from './core.schema.js';
 
+// login request schema
 export const loginRequestSchema = z.object({
   email: z
     .string({
@@ -15,12 +16,15 @@ export const loginRequestSchema = z.object({
   }),
 });
 
+// login response schema
+
 export const loginResponseSchema = createResponseSchema(
   z.object({
     accessToken: z.string(),
   }),
 );
 
+// signup request schema
 export const signupRequestSchema = z.object({
   email: z
     .string({
@@ -41,4 +45,5 @@ export const signupRequestSchema = z.object({
   }),
 });
 
+// signup response schema
 export const signupResponseSchema = createResponseSchema(z.any());

--- a/src/v1/schemas/user.schema.ts
+++ b/src/v1/schemas/user.schema.ts
@@ -1,6 +1,5 @@
-import { z } from "zod";
-
+import { z } from 'zod';
 
 export const getUserParamsSchema = z.object({
-    id: z.string().min(1)
+  id: z.string().min(1),
 });

--- a/src/v1/schemas/user.schema.ts
+++ b/src/v1/schemas/user.schema.ts
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+
+export const getUserParamsSchema = z.object({
+    id: z.string().min(1)
+});

--- a/src/v1/services/auth.service.ts
+++ b/src/v1/services/auth.service.ts
@@ -7,7 +7,7 @@ import {
   signupRequestSchema,
   signupResponseSchema,
 } from '../schemas/auth.schema.js';
-import { STATUS } from '../constants/status.js';
+import { STATUS } from '../constants/status.ts';
 
 export async function signupService(
   data: z.infer<typeof signupRequestSchema>,

--- a/test/v1/services/auth.service.test.ts
+++ b/test/v1/services/auth.service.test.ts
@@ -1,0 +1,53 @@
+import { FastifyBaseLogger } from 'fastify';
+import { signupService, loginService } from '../../../src/v1/services/auth.service';
+import { z } from 'zod';
+import { loginRequestSchema, signupRequestSchema } from '../../../src/v1/schemas/auth.schema';
+import { STATUS } from '../../../src/v1/constants/status';
+
+describe('Auth Service', () => {
+  const mockLogger: FastifyBaseLogger = {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+    trace: jest.fn(),
+    fatal: jest.fn(),
+    child: jest.fn(),
+  } as unknown as FastifyBaseLogger;
+
+  describe('signupService', () => {
+    it('should return success status and message', async () => {
+      const data: z.infer<typeof signupRequestSchema> = {
+        email: 'testuser',
+        password: 'testpassword',
+        name: 'testname',
+      };
+
+      const response = await signupService(data, mockLogger);
+
+      expect(response).toEqual({
+        status: STATUS.SUCCESS,
+        message: 'User information retrieved successfully',
+      });
+    });
+  });
+
+  describe('loginService', () => {
+    it('should return success status, message, and access token', async () => {
+      const data: z.infer<typeof loginRequestSchema> = {
+        email: 'testuser',
+        password: 'testpassword',
+      };
+
+      const response = await loginService(data, mockLogger);
+
+      expect(response).toEqual({
+        status: STATUS.SUCCESS,
+        message: 'User information retrieved successfully',
+        data: {
+          accessToken: 'tmp-access-token',
+        },
+      });
+    });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,13 @@
   "extends": "fastify-tsconfig",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "./",
+    "baseUrl": "./",
+    "paths": {
+      "@src/*": ["src/*"],
+    },
+    "noEmit": true,
+    "allowImportingTsExtensions": true
   },
   "include": ["@types", "src/**/*.ts"]
 }


### PR DESCRIPTION
## 🔗 반영 브랜치

#5 feature/5-에러-핸들러-구현 -> dev

## 📝 작업 내용

- 사용자의 request body, params 혹은 응답의 body에 대해 만들어놓은 api의 `schema`를 기반으로 검증 로직을 적용했습니다.
- fastify에 에러핸들러를 추가했습니다. 이제부터 에러가 발생하게되면 해당 핸들러에서 처리하게 됩니다.
- 여러 커스텀 예외를 만들었습니다. 403, 404와 같은 예외를 정의해 두었습니다.
- Jest를 설치하여 간단한 유닉 테스트 코드를 작성하였습니다. `npm run test`로 실행 가능합니다.