### PR TITLE
[REFACTOR] 17 di적용 및 dip준수

### DIFF
--- a/@types/global.d.ts
+++ b/@types/global.d.ts
@@ -1,4 +1,5 @@
-// global.d.ts
+import { ProcessEnv } from 'process';
+
 export {};
 
 declare global {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -21,7 +21,7 @@ export default tseslint.config(
       parser: tseslintParser, // TypeScript 파서를 설정
       parserOptions: {
         sourceType: 'module',
-        project: './tsconfig.json', // tsconfig 파일 경로
+        project: './tsconfig.eslint.json', // tsconfig 파일 경로
       },
     },
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "watch:ts": "tsx watch src/main.ts",
     "build:ts": "tsc",
     "clean": "rm -rf dist",
-    "lint": "eslint . --ext .ts --fix",
+    "lint": "eslint ./src --ext .ts --fix",
     "format": "prettier --write \"src/**/*.{ts,tsx}\"",
     "test": "vitest",
     "test:watch": "vitest watch",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
+    "@fastify/awilix": "^7.0.0",
     "@fastify/cookie": "^11.0.2",
     "@fastify/cors": "^11.0.0",
     "@fastify/jwt": "^9.1.0",
@@ -33,6 +34,7 @@
     "@fastify/swagger-ui": "^5.2.2",
     "@prisma/client": "^6.5.0",
     "@types/uuid": "^10.0.0",
+    "awilix": "^12.0.5",
     "c8": "^10.1.3",
     "close-with-grace": "^2.2.0",
     "fastify": "^5.2.1",

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,7 +2,6 @@ import { FastifyError, FastifyInstance, FastifyReply, FastifyRequest } from 'fas
 
 import routeV1 from './v1/index.js';
 import { STATUS } from './v1/common/constants/status.js';
-import jwtPlugin from './v1/common/plugins/jwt-plugin.js';
 
 export default async function app(fastify: FastifyInstance) {
   fastify.setErrorHandler((error: FastifyError, request: FastifyRequest, reply: FastifyReply) => {
@@ -17,6 +16,5 @@ export default async function app(fastify: FastifyInstance) {
     });
   });
 
-  fastify.register(jwtPlugin);
   fastify.register(routeV1, { prefix: '/v1' });
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -55,6 +55,7 @@ async function setDiContainer(server: FastifyInstance) {
   diContainer.register({
     prisma: asValue(prisma),
     jwt: asValue(server.jwt),
+    logger: asValue(server.log),
   });
   await diContainer.loadModules(['./**/*.repository.js'], {
     esModules: true,

--- a/src/main.ts
+++ b/src/main.ts
@@ -70,7 +70,7 @@ async function setDiContainer(server: FastifyInstance) {
     esModules: true,
     formatName: 'camelCase',
     resolverOptions: {
-      lifetime: 'SCOPED',
+      lifetime: Lifetime.SINGLETON,
       register: asClass,
       injectionMode: 'CLASSIC',
     },

--- a/src/v1/apis/auth/auth.controller.ts
+++ b/src/v1/apis/auth/auth.controller.ts
@@ -2,11 +2,13 @@ import { FastifyReply, FastifyRequest } from 'fastify';
 
 import { signupService, loginService, generateRefreshToken } from '../../apis/auth/auth.service.js';
 import { loginRequestSchema, signupRequestSchema } from '../auth/auth.schema.js';
+import { UserRepositoryImpl } from '../../repositories/user.repository.js';
+import prisma from '../../common/utils/prisma.js';
 
 export async function signupController(request: FastifyRequest, reply: FastifyReply) {
   try {
     const body = signupRequestSchema.parse(request.body);
-    const result = await signupService(body, request.log);
+    const result = await signupService(body, request.log, new UserRepositoryImpl(prisma));
     reply.status(201).send(result);
   } catch (error) {
     reply.status(400).send({ error });
@@ -16,7 +18,12 @@ export async function signupController(request: FastifyRequest, reply: FastifyRe
 export async function loginController(request: FastifyRequest, reply: FastifyReply) {
   try {
     const body = loginRequestSchema.parse(request.body);
-    const result = await loginService(body, request.log, request.server.jwt);
+    const result = await loginService(
+      body,
+      request.log,
+      request.server.jwt,
+      new UserRepositoryImpl(prisma),
+    );
     const refreshToken = await generateRefreshToken();
 
     reply.header(

--- a/src/v1/apis/auth/auth.controller.ts
+++ b/src/v1/apis/auth/auth.controller.ts
@@ -1,14 +1,14 @@
 import { FastifyReply, FastifyRequest } from 'fastify';
 
-import { signupService, loginService, generateRefreshToken } from '../../apis/auth/auth.service.js';
-import { loginRequestSchema, signupRequestSchema } from '../auth/auth.schema.js';
-import { UserRepositoryImpl } from '../../repositories/user.repository.js';
-import prisma from '../../common/utils/prisma.js';
+import { signupService, loginService, generateRefreshToken } from './auth.service.js';
+import { loginRequestSchema, signupRequestSchema } from './auth.schema.js';
+import { UserRepository } from '../../repositories/user.repository.js';
 
 export async function signupController(request: FastifyRequest, reply: FastifyReply) {
   try {
+    const repository: UserRepository = request.diScope.resolve('userRepository');
     const body = signupRequestSchema.parse(request.body);
-    const result = await signupService(body, request.log, new UserRepositoryImpl(prisma));
+    const result = await signupService(body, request.log, repository);
     reply.status(201).send(result);
   } catch (error) {
     reply.status(400).send({ error });
@@ -17,13 +17,9 @@ export async function signupController(request: FastifyRequest, reply: FastifyRe
 
 export async function loginController(request: FastifyRequest, reply: FastifyReply) {
   try {
+    const repository: UserRepository = request.diScope.resolve('userRepository');
     const body = loginRequestSchema.parse(request.body);
-    const result = await loginService(
-      body,
-      request.log,
-      request.server.jwt,
-      new UserRepositoryImpl(prisma),
-    );
+    const result = await loginService(body, request.log, request.server.jwt, repository);
     const refreshToken = await generateRefreshToken();
 
     reply.header(

--- a/src/v1/apis/auth/auth.controller.ts
+++ b/src/v1/apis/auth/auth.controller.ts
@@ -4,13 +4,7 @@ import { loginRequestSchema, signupRequestSchema } from './auth.schema.js';
 import AuthService from './auth.service.js';
 
 export default class AuthController {
-  private readonly authService: AuthService;
-
-  constructor(authService: AuthService) {
-    this.authService = authService;
-    this.signup = this.signup.bind(this);
-    this.login = this.login.bind(this);
-  }
+  constructor(private readonly authService: AuthService) {}
 
   signup = async (request: FastifyRequest, reply: FastifyReply) => {
     try {

--- a/src/v1/apis/auth/auth.controller.ts
+++ b/src/v1/apis/auth/auth.controller.ts
@@ -12,7 +12,7 @@ export default class AuthController {
     this.login = this.login.bind(this);
   }
 
-  async signup(request: FastifyRequest, reply: FastifyReply) {
+  signup = async (request: FastifyRequest, reply: FastifyReply) => {
     try {
       const body = signupRequestSchema.parse(request.body);
       request.log.info(body, 'Signup request received');
@@ -22,9 +22,9 @@ export default class AuthController {
       request.log.error(error, 'Error in signup');
       reply.status(400).send({ error });
     }
-  }
+  };
 
-  async login(request: FastifyRequest, reply: FastifyReply) {
+  login = async (request: FastifyRequest, reply: FastifyReply) => {
     try {
       const body = loginRequestSchema.parse(request.body);
       const result = await this.authService.login(body);
@@ -39,5 +39,5 @@ export default class AuthController {
       request.log.error(error, 'Error in login');
       reply.status(401).send({ error });
     }
-  }
+  };
 }

--- a/src/v1/apis/auth/auth.route.ts
+++ b/src/v1/apis/auth/auth.route.ts
@@ -1,20 +1,22 @@
 import { FastifyInstance } from 'fastify';
 
-import { loginController, signupController } from '../../apis/auth/auth.controller.js';
+import AuthController from '../../apis/auth/auth.controller.js';
 import {
   loginRequestSchema,
   loginResponseSchema,
   signupRequestSchema,
   signupResponseSchema,
-} from '../../apis/auth/auth.schema.js';
+} from './auth.schema.js';
 import { addRoutes, Route } from '../../common/utils/router.js';
 
 export default async function authRoutes(fastify: FastifyInstance) {
+  const authController: AuthController = fastify.diContainer.resolve('authController');
+
   const routes: Array<Route> = [
     {
       method: 'POST',
       url: '/',
-      handler: signupController,
+      handler: authController.signup,
       options: {
         schema: {
           tags: ['auth'],
@@ -28,7 +30,7 @@ export default async function authRoutes(fastify: FastifyInstance) {
     {
       method: 'POST',
       url: '/login',
-      handler: loginController,
+      handler: authController.login,
       options: {
         schema: {
           tags: ['auth'],
@@ -40,5 +42,5 @@ export default async function authRoutes(fastify: FastifyInstance) {
       },
     },
   ];
-  addRoutes(fastify, routes);
+  await addRoutes(fastify, routes);
 }

--- a/src/v1/apis/auth/auth.service.ts
+++ b/src/v1/apis/auth/auth.service.ts
@@ -3,29 +3,32 @@ import { FastifyBaseLogger } from 'fastify';
 import { JWT } from '@fastify/jwt';
 import { v4 as uuidv4 } from 'uuid';
 
-import prisma from '../..//common/utils/prisma.js';
 import {
   loginRequestSchema,
   loginResponseSchema,
   signupRequestSchema,
   signupResponseSchema,
 } from '../auth/auth.schema.js';
-import { STATUS } from '../..//common/constants/status.js';
+import { STATUS } from '../../common/constants/status.js';
+import { UserRepository } from '../../repositories/user.repository.js';
+import { NotFoundException } from '@src/v1/common/exceptions/core.error.js';
 
 export async function signupService(
   data: z.infer<typeof signupRequestSchema>,
   logger: FastifyBaseLogger,
+  userRepository: UserRepository,
 ): Promise<z.infer<typeof signupResponseSchema>> {
   logger.info('data', data);
 
-  const newUser = await prisma.user.create({
-    data: {
-      name: data.name,
-      email: data.email,
-      password_hash: data.password,
-      two_factor_enabled: false,
-    },
+  const newUser = await userRepository.create({
+    name: data.name,
+    email: data.email,
+    password_hash: data.password,
+    two_factor_enabled: false,
   });
+  if (!newUser) {
+    throw new NotFoundException('User not found');
+  }
 
   logger.info('New user created', newUser);
 
@@ -39,12 +42,9 @@ export async function loginService(
   data: z.infer<typeof loginRequestSchema>,
   logger: FastifyBaseLogger,
   jwt: JWT,
+  userRepository: UserRepository,
 ): Promise<z.infer<typeof loginResponseSchema>> {
-  const foundUser = await prisma.user.findUnique({
-    where: {
-      email: data.email,
-    },
-  });
+  const foundUser = await userRepository.findByEmail(data.email);
   if (!foundUser) {
     return {
       status: STATUS.ERROR,

--- a/src/v1/apis/auth/auth.service.ts
+++ b/src/v1/apis/auth/auth.service.ts
@@ -14,15 +14,11 @@ import { NotFoundException } from '../../common/exceptions/core.error.js';
 import { FastifyBaseLogger } from 'fastify';
 
 export default class AuthService {
-  private readonly userRepository: UserRepository;
-  private readonly jwt: JWT;
-  private readonly logger: FastifyBaseLogger;
-
-  constructor(userRepository: UserRepository, jwt: JWT, logger: FastifyBaseLogger) {
-    this.userRepository = userRepository;
-    this.jwt = jwt;
-    this.logger = logger;
-  }
+  constructor(
+    private readonly userRepository: UserRepository,
+    private readonly jwt: JWT,
+    private readonly logger: FastifyBaseLogger,
+  ) {}
 
   async signup(
     data: z.infer<typeof signupRequestSchema>,

--- a/src/v1/apis/auth/auth.service.ts
+++ b/src/v1/apis/auth/auth.service.ts
@@ -11,7 +11,7 @@ import {
 } from '../auth/auth.schema.js';
 import { STATUS } from '../../common/constants/status.js';
 import { UserRepository } from '../../repositories/user.repository.js';
-import { NotFoundException } from '@src/v1/common/exceptions/core.error.js';
+import { NotFoundException } from '../../common/exceptions/core.error.js';
 
 export async function signupService(
   data: z.infer<typeof signupRequestSchema>,

--- a/src/v1/apis/auth/auth.service.ts
+++ b/src/v1/apis/auth/auth.service.ts
@@ -8,7 +8,7 @@ import {
   loginResponseSchema,
   signupRequestSchema,
   signupResponseSchema,
-} from '../auth/auth.schema.js';
+} from './auth.schema.js';
 import { STATUS } from '../../common/constants/status.js';
 import { UserRepository } from '../../repositories/user.repository.js';
 import { NotFoundException } from '../../common/exceptions/core.error.js';

--- a/src/v1/apis/auth/auth.service.ts
+++ b/src/v1/apis/auth/auth.service.ts
@@ -11,14 +11,17 @@ import {
 import { STATUS } from '../../common/constants/status.js';
 import { UserRepository } from '../../repositories/user.repository.js';
 import { NotFoundException } from '../../common/exceptions/core.error.js';
+import { FastifyBaseLogger } from 'fastify';
 
 export default class AuthService {
   private readonly userRepository: UserRepository;
   private readonly jwt: JWT;
+  private readonly logger: FastifyBaseLogger;
 
-  constructor(userRepository: UserRepository, jwt: JWT) {
+  constructor(userRepository: UserRepository, jwt: JWT, logger: FastifyBaseLogger) {
     this.userRepository = userRepository;
     this.jwt = jwt;
+    this.logger = logger;
   }
 
   async signup(
@@ -33,6 +36,8 @@ export default class AuthService {
     if (!newUser) {
       throw new NotFoundException('User not found');
     }
+
+    this.logger.info(`User ${newUser.id} created successfully`);
 
     return {
       status: STATUS.SUCCESS,

--- a/src/v1/apis/auth/auth.service.ts
+++ b/src/v1/apis/auth/auth.service.ts
@@ -1,5 +1,4 @@
 import { z } from 'zod';
-import { FastifyBaseLogger } from 'fastify';
 import { JWT } from '@fastify/jwt';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -13,54 +12,55 @@ import { STATUS } from '../../common/constants/status.js';
 import { UserRepository } from '../../repositories/user.repository.js';
 import { NotFoundException } from '../../common/exceptions/core.error.js';
 
-export async function signupService(
-  data: z.infer<typeof signupRequestSchema>,
-  logger: FastifyBaseLogger,
-  userRepository: UserRepository,
-): Promise<z.infer<typeof signupResponseSchema>> {
-  logger.info('data', data);
+export default class AuthService {
+  private readonly userRepository: UserRepository;
+  private readonly jwt: JWT;
 
-  const newUser = await userRepository.create({
-    name: data.name,
-    email: data.email,
-    password_hash: data.password,
-    two_factor_enabled: false,
-  });
-  if (!newUser) {
-    throw new NotFoundException('User not found');
+  constructor(userRepository: UserRepository, jwt: JWT) {
+    this.userRepository = userRepository;
+    this.jwt = jwt;
   }
 
-  logger.info('New user created', newUser);
+  async signup(
+    data: z.infer<typeof signupRequestSchema>,
+  ): Promise<z.infer<typeof signupResponseSchema>> {
+    const newUser = await this.userRepository.create({
+      name: data.name,
+      email: data.email,
+      password_hash: data.password,
+      two_factor_enabled: false,
+    });
+    if (!newUser) {
+      throw new NotFoundException('User not found');
+    }
 
-  return {
-    status: STATUS.SUCCESS,
-    message: 'User information retrieved successfully',
-  };
-}
-
-export async function loginService(
-  data: z.infer<typeof loginRequestSchema>,
-  logger: FastifyBaseLogger,
-  jwt: JWT,
-  userRepository: UserRepository,
-): Promise<z.infer<typeof loginResponseSchema>> {
-  const foundUser = await userRepository.findByEmail(data.email);
-  if (!foundUser) {
     return {
-      status: STATUS.ERROR,
-      message: 'User not found',
+      status: STATUS.SUCCESS,
+      message: 'User information retrieved successfully',
     };
   }
 
-  return {
-    status: STATUS.SUCCESS,
-    message: 'User information retrieved successfully',
-    data: {
-      accessToken: jwt.sign({ id: foundUser.id, email: foundUser.email }),
-    },
-  };
-}
+  async login(
+    data: z.infer<typeof loginRequestSchema>,
+  ): Promise<z.infer<typeof loginResponseSchema>> {
+    const foundUser = await this.userRepository.findByEmail(data.email);
+    if (!foundUser) {
+      return {
+        status: STATUS.ERROR,
+        message: 'User not found',
+      };
+    }
 
-export async function generateRefreshToken(): Promise<string> {
-  return uuidv4();
+    return {
+      status: STATUS.SUCCESS,
+      message: 'User information retrieved successfully',
+      data: {
+        accessToken: this.jwt.sign({ id: foundUser.id, email: foundUser.email }),
+      },
+    };
+  }
+
+  async generateRefreshToken(): Promise<string> {
+    return uuidv4();
+  }
 }

--- a/src/v1/apis/users/users.controller.ts
+++ b/src/v1/apis/users/users.controller.ts
@@ -4,7 +4,7 @@ import { getUserParamsSchema } from './user.schema.js';
 import { ForbiddenException } from '../../common/exceptions/core.error.js';
 
 export default class UsersController {
-  async findUser(request: FastifyRequest, reply: FastifyReply) {
+  findUser = async (request: FastifyRequest, reply: FastifyReply) => {
     const params = getUserParamsSchema.parse(request.params);
     const user = request.me;
 
@@ -13,5 +13,5 @@ export default class UsersController {
     }
 
     reply.code(200).send('hello');
-  }
+  };
 }

--- a/src/v1/apis/users/users.controller.ts
+++ b/src/v1/apis/users/users.controller.ts
@@ -1,15 +1,17 @@
 import { FastifyReply, FastifyRequest } from 'fastify';
 
-import { getUserParamsSchema } from '../users/user.schema.js';
+import { getUserParamsSchema } from './user.schema.js';
 import { ForbiddenException } from '../../common/exceptions/core.error.js';
 
-export async function findUserController(request: FastifyRequest, reply: FastifyReply) {
-  const params = getUserParamsSchema.parse(request.params);
-  const user = request.me;
+export default class UsersController {
+  async findUser(request: FastifyRequest, reply: FastifyReply) {
+    const params = getUserParamsSchema.parse(request.params);
+    const user = request.me;
 
-  if (user.id !== params.id) {
-    throw new ForbiddenException('You are not authorized to view this user');
+    if (user.id !== params.id) {
+      throw new ForbiddenException('You are not authorized to view this user');
+    }
+
+    reply.code(200).send('hello');
   }
-
-  reply.code(200).send('hello');
 }

--- a/src/v1/apis/users/users.route.ts
+++ b/src/v1/apis/users/users.route.ts
@@ -12,6 +12,7 @@ export default async function usersRoutes(fastify: FastifyInstance) {
       handler: findUserController,
       options: {
         schema: {
+          tags: ['users'],
           params: getUserParamsSchema,
         },
         auth: true,

--- a/src/v1/apis/users/users.route.ts
+++ b/src/v1/apis/users/users.route.ts
@@ -1,15 +1,16 @@
 import { FastifyInstance } from 'fastify';
 
-import { findUserController } from '../../apis/users/users.controller.js';
-import { getUserParamsSchema } from '../users/user.schema.js';
+import { getUserParamsSchema } from './user.schema.js';
 import { addRoutes, Route } from '../../common/utils/router.js';
+import UsersController from './users.controller.js';
 
 export default async function usersRoutes(fastify: FastifyInstance) {
+  const usersController: UsersController = fastify.diContainer.resolve('usersController');
   const routes: Array<Route> = [
     {
       method: 'GET',
       url: '/:id',
-      handler: findUserController,
+      handler: usersController.findUser,
       options: {
         schema: {
           tags: ['users'],
@@ -19,5 +20,5 @@ export default async function usersRoutes(fastify: FastifyInstance) {
       },
     },
   ];
-  addRoutes(fastify, routes);
+  await addRoutes(fastify, routes);
 }

--- a/src/v1/repositories/base.repository.ts
+++ b/src/v1/repositories/base.repository.ts
@@ -1,0 +1,11 @@
+export interface BaseRepository<T, CreateInput = Partial<T>, UpdateInput = Partial<T>> {
+  findById(id: number): Promise<T | null>;
+
+  create(data: CreateInput): Promise<T>;
+
+  update(id: number, data: UpdateInput): Promise<T>;
+
+  delete(id: number): Promise<T>;
+
+  findAll(): Promise<T[]>;
+}

--- a/src/v1/repositories/base.repository.ts
+++ b/src/v1/repositories/base.repository.ts
@@ -1,4 +1,4 @@
-export interface BaseRepository<T, CreateInput = Partial<T>, UpdateInput = Partial<T>> {
+export interface BaseRepository<T, CreateInput, UpdateInput> {
   findById(id: number): Promise<T | null>;
 
   create(data: CreateInput): Promise<T>;

--- a/src/v1/repositories/user.repository.ts
+++ b/src/v1/repositories/user.repository.ts
@@ -1,0 +1,26 @@
+import { BaseRepository } from '@src/v1/repositories/base.repository.js';
+import { Prisma, PrismaClient, User } from '@prisma/client';
+
+export class UserRepository implements BaseRepository<User, Prisma.UserCreateInput> {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  create(data: Prisma.UserCreateInput): Promise<User> {
+    return this.prisma.user.create({ data });
+  }
+
+  delete(id: number): Promise<User> {
+    return this.prisma.user.delete({ where: { id } });
+  }
+
+  findAll(): Promise<User[]> {
+    return this.prisma.user.findMany();
+  }
+
+  findById(id: number): Promise<User | null> {
+    return this.prisma.user.findUnique({ where: { id } });
+  }
+
+  update(id: number, data: Partial<User>): Promise<User> {
+    return this.prisma.user.update({ where: { id }, data });
+  }
+}

--- a/src/v1/repositories/user.repository.ts
+++ b/src/v1/repositories/user.repository.ts
@@ -7,11 +7,7 @@ export interface UserRepository
 }
 
 export default class UserRepositoryImpl implements UserRepository {
-  private readonly prisma: PrismaClient;
-
-  constructor(prisma: PrismaClient) {
-    this.prisma = prisma;
-  }
+  constructor(private readonly prisma: PrismaClient) {}
 
   create(data: Prisma.UserCreateInput): Promise<User> {
     return this.prisma.user.create({ data });

--- a/src/v1/repositories/user.repository.ts
+++ b/src/v1/repositories/user.repository.ts
@@ -1,7 +1,12 @@
 import { BaseRepository } from '@src/v1/repositories/base.repository.js';
 import { Prisma, PrismaClient, User } from '@prisma/client';
 
-export class UserRepository implements BaseRepository<User, Prisma.UserCreateInput> {
+export interface UserRepository
+  extends BaseRepository<User, Prisma.UserCreateInput, Prisma.UserUpdateInput> {
+  findByEmail(email: string): Promise<User | null>;
+}
+
+export class UserRepositoryImpl implements UserRepository {
   constructor(private readonly prisma: PrismaClient) {}
 
   create(data: Prisma.UserCreateInput): Promise<User> {
@@ -16,11 +21,15 @@ export class UserRepository implements BaseRepository<User, Prisma.UserCreateInp
     return this.prisma.user.findMany();
   }
 
+  findByEmail(email: string): Promise<User | null> {
+    return this.prisma.user.findUnique({ where: { email } });
+  }
+
   findById(id: number): Promise<User | null> {
     return this.prisma.user.findUnique({ where: { id } });
   }
 
-  update(id: number, data: Partial<User>): Promise<User> {
+  update(id: number, data: Prisma.UserUpdateInput): Promise<User> {
     return this.prisma.user.update({ where: { id }, data });
   }
 }

--- a/src/v1/repositories/user.repository.ts
+++ b/src/v1/repositories/user.repository.ts
@@ -1,4 +1,4 @@
-import { BaseRepository } from '@src/v1/repositories/base.repository.js';
+import { BaseRepository } from './base.repository.js';
 import { Prisma, PrismaClient, User } from '@prisma/client';
 
 export interface UserRepository

--- a/src/v1/repositories/user.repository.ts
+++ b/src/v1/repositories/user.repository.ts
@@ -6,8 +6,12 @@ export interface UserRepository
   findByEmail(email: string): Promise<User | null>;
 }
 
-export class UserRepositoryImpl implements UserRepository {
-  constructor(private readonly prisma: PrismaClient) {}
+export default class UserRepositoryImpl implements UserRepository {
+  private readonly prisma!: PrismaClient;
+
+  constructor(prisma: PrismaClient) {
+    this.prisma = prisma;
+  }
 
   create(data: Prisma.UserCreateInput): Promise<User> {
     return this.prisma.user.create({ data });

--- a/src/v1/repositories/user.repository.ts
+++ b/src/v1/repositories/user.repository.ts
@@ -7,7 +7,7 @@ export interface UserRepository
 }
 
 export default class UserRepositoryImpl implements UserRepository {
-  private readonly prisma!: PrismaClient;
+  private readonly prisma: PrismaClient;
 
   constructor(prisma: PrismaClient) {
     this.prisma = prisma;

--- a/test/v1/apis/auth/services/auth.service.spec.ts
+++ b/test/v1/apis/auth/services/auth.service.spec.ts
@@ -1,11 +1,14 @@
 import { z } from 'zod';
-import { loginRequestSchema, signupRequestSchema } from '@src/v1/apis/auth/auth.schema.js';
-import { STATUS } from '@src/v1/common/constants/status.js';
+import {
+  loginRequestSchema,
+  signupRequestSchema,
+} from '../../../../../src/v1/apis/auth/auth.schema.js';
+import { STATUS } from '../../../../../src/v1/common/constants/status.js';
 import { describe, expect, it, vi } from 'vitest';
 import { mockJwt } from '../../../mocks/mockJwt.js';
 import { mockLogger } from '../../../mocks/mockLogger.js';
-import { loginService, signupService } from '@src/v1/apis/auth/auth.service.js';
-import { UserRepository } from '@src/v1/repositories/user.repository.js';
+import { loginService, signupService } from '../../../../../src/v1/apis/auth/auth.service.js';
+import { UserRepository } from '../../../../../src/v1/repositories/user.repository.js';
 
 const mockedUserRepository: UserRepository = {
   create: vi.fn(),

--- a/test/v1/apis/auth/services/auth.service.spec.ts
+++ b/test/v1/apis/auth/services/auth.service.spec.ts
@@ -8,7 +8,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { mockJwt } from '../../../mocks/mockJwt.js';
 import { mockLogger } from '../../../mocks/mockLogger.js';
 import { UserRepository } from '../../../../../src/v1/repositories/user.repository.js';
-import AuthService from '../../../../../src/v1/apis/auth/auth.service';
+import AuthService from '../../../../../src/v1/apis/auth/auth.service.js';
 
 const mockedUserRepository: UserRepository = {
   create: vi.fn(),
@@ -44,7 +44,7 @@ describe('Auth Service', () => {
         created_at: new Date(),
         updated_at: new Date(),
       });
-      const response = await authService.signup(data, mockLogger, mockedUserRepository);
+      const response = await authService.signup(data);
 
       expect(response).toEqual({
         status: STATUS.SUCCESS,
@@ -70,7 +70,7 @@ describe('Auth Service', () => {
         created_at: new Date(),
         updated_at: new Date(),
       });
-      const response = await authService.login(data, mockLogger, mockJwt, mockedUserRepository);
+      const response = await authService.login(data);
 
       expect(response).toEqual({
         status: STATUS.SUCCESS,

--- a/test/v1/apis/auth/services/auth.service.spec.ts
+++ b/test/v1/apis/auth/services/auth.service.spec.ts
@@ -1,11 +1,20 @@
 import { z } from 'zod';
 import { loginRequestSchema, signupRequestSchema } from '@src/v1/apis/auth/auth.schema.js';
 import { STATUS } from '@src/v1/common/constants/status.js';
-import { describe, expect, it } from 'vitest';
-import prisma from '../../../mocks/mockPrisma.js';
+import { describe, expect, it, vi } from 'vitest';
 import { mockJwt } from '../../../mocks/mockJwt.js';
 import { mockLogger } from '../../../mocks/mockLogger.js';
 import { loginService, signupService } from '@src/v1/apis/auth/auth.service.js';
+import { UserRepository } from '@src/v1/repositories/user.repository.js';
+
+const mockedUserRepository: UserRepository = {
+  create: vi.fn(),
+  findByEmail: vi.fn(),
+  delete: vi.fn(),
+  update: vi.fn(),
+  findAll: vi.fn(),
+  findById: vi.fn(),
+};
 
 describe('Auth Service', () => {
   describe('signupService', () => {
@@ -16,7 +25,7 @@ describe('Auth Service', () => {
         name: 'testname',
       };
 
-      prisma.user.create.mockResolvedValue({
+      (mockedUserRepository.create as ReturnType<typeof vi.fn>).mockResolvedValue({
         id: 1,
         email: 'testuser',
         password_hash: 'testpassword',
@@ -26,8 +35,7 @@ describe('Auth Service', () => {
         created_at: new Date(),
         updated_at: new Date(),
       });
-
-      const response = await signupService(data, mockLogger);
+      const response = await signupService(data, mockLogger, mockedUserRepository);
 
       expect(response).toEqual({
         status: STATUS.SUCCESS,
@@ -43,7 +51,7 @@ describe('Auth Service', () => {
         password: 'testpassword',
       };
 
-      prisma.user.findUnique.mockResolvedValue({
+      (mockedUserRepository.findByEmail as ReturnType<typeof vi.fn>).mockResolvedValue({
         id: 1,
         email: 'testuser',
         password_hash: 'testpassword',
@@ -53,7 +61,7 @@ describe('Auth Service', () => {
         created_at: new Date(),
         updated_at: new Date(),
       });
-      const response = await loginService(data, mockLogger, mockJwt);
+      const response = await loginService(data, mockLogger, mockJwt, mockedUserRepository);
 
       expect(response).toEqual({
         status: STATUS.SUCCESS,

--- a/test/v1/apis/auth/services/auth.service.spec.ts
+++ b/test/v1/apis/auth/services/auth.service.spec.ts
@@ -4,11 +4,11 @@ import {
   signupRequestSchema,
 } from '../../../../../src/v1/apis/auth/auth.schema.js';
 import { STATUS } from '../../../../../src/v1/common/constants/status.js';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { mockJwt } from '../../../mocks/mockJwt.js';
 import { mockLogger } from '../../../mocks/mockLogger.js';
-import { loginService, signupService } from '../../../../../src/v1/apis/auth/auth.service.js';
 import { UserRepository } from '../../../../../src/v1/repositories/user.repository.js';
+import AuthService from '../../../../../src/v1/apis/auth/auth.service';
 
 const mockedUserRepository: UserRepository = {
   create: vi.fn(),
@@ -20,6 +20,12 @@ const mockedUserRepository: UserRepository = {
 };
 
 describe('Auth Service', () => {
+  let authService: AuthService;
+
+  beforeEach(() => {
+    authService = new AuthService(mockedUserRepository, mockJwt, mockLogger);
+  });
+
   describe('signupService', () => {
     it('should return success status and message', async () => {
       const data: z.infer<typeof signupRequestSchema> = {
@@ -38,7 +44,7 @@ describe('Auth Service', () => {
         created_at: new Date(),
         updated_at: new Date(),
       });
-      const response = await signupService(data, mockLogger, mockedUserRepository);
+      const response = await authService.signup(data, mockLogger, mockedUserRepository);
 
       expect(response).toEqual({
         status: STATUS.SUCCESS,
@@ -64,7 +70,7 @@ describe('Auth Service', () => {
         created_at: new Date(),
         updated_at: new Date(),
       });
-      const response = await loginService(data, mockLogger, mockJwt, mockedUserRepository);
+      const response = await authService.login(data, mockLogger, mockJwt, mockedUserRepository);
 
       expect(response).toEqual({
         status: STATUS.SUCCESS,

--- a/test/vitest.setup.ts
+++ b/test/vitest.setup.ts
@@ -1,3 +1,3 @@
 import './v1/mocks/mockPrisma';
-import './v1/mocks/mockjwt';
+import './v1/mocks/mockJwt';
 import './v1/mocks/mockLogger';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,10 +4,5 @@
     "outDir": "dist",
     "rootDir": "./",
     "baseUrl": "./",
-    "paths": {
-      "@src/*": [
-        "src/*"
-      ]
-    }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,5 +4,6 @@
     "outDir": "dist",
     "rootDir": "./",
     "baseUrl": "./",
-  }
+  },
+  "include": ["src/**/*.*", "src/**/*d.ts", "@types"],
 }


### PR DESCRIPTION
## 🔗 반영 브랜치

#17  refactor/17-di적용-및-dip준수 -> main

## 📝 작업 내용

- DI 적용을 위해 `awilix`를 적용하였습니다.
- DI 적용:
    <img width="944" alt="image" src="https://github.com/user-attachments/assets/5c337b8d-fe91-42e1-8eec-cdbf4eca48ed" />
    - `*.service.ts`, `*.repository.ts`, `*.controller.ts`의 클래스들은 DI 컨테이너에 자동으로 등록이 됩니다.
    - Auth, Users 등 주요 도메인별 서비스 및 컨트롤러에 DI 적용 및 DIP(Dependency Inversion Principle) 준수를 적용하였습니다.

- JWT 플러그인 및 Logger 설정 개선:
    - Fastify 인스턴스에 JWT 플러그인을 먼저 등록하고, 이후 DI 컨테이너에 server.jwt와 server.log를 주입하도록 순서를 변경하였습니다.

- Prisma 의존성 정리:
    - Auth 서비스에서 Prisma를 직접 참조하지 않고, DI 컨테이너를 통해 주입받도록 변경하여 의존성을 분리하였습니다.

- 테스트 코드 수정:
    - 변경된 DI 설정에 맞춰 테스트 코드(mock 객체 등)를 업데이트 하였습니다.

## 💬 리뷰 요구사항(선택)

> awailix 의 작동 방식을 중점으로 코드리뷰 부탁드립니다. 

> 테스트 코드도 꼭 리뷰 부탁드리겠습니다.
