### PR TITLE
[FEAT] 14 서버간 통신 인터페이스 구성

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "fastify": "^5.2.1",
     "fastify-plugin": "^5.0.1",
     "fastify-type-provider-zod": "^4.0.2",
+    "got": "^14.4.6",
     "ioredis": "^5.6.0",
     "pino": "^9.6.0",
     "pino-pretty": "^13.0.0",

--- a/src/container.ts
+++ b/src/container.ts
@@ -2,6 +2,7 @@ import { FastifyInstance } from 'fastify';
 import { diContainer, fastifyAwilixPlugin } from '@fastify/awilix';
 import { asClass, asValue, Lifetime } from 'awilix';
 import prisma from './v1/common/utils/prisma.js';
+import { GotHttpClient } from './v1/common/http/got/http.client.js';
 
 export async function setDiContainer(server: FastifyInstance) {
   server.register(fastifyAwilixPlugin, {
@@ -15,6 +16,9 @@ export async function setDiContainer(server: FastifyInstance) {
     jwt: asValue(server.jwt),
     logger: asValue(server.log),
     redisClient: asValue(server.redis),
+    httpClient: asClass(GotHttpClient)
+      .inject(() => ({ baseURL: 'https://api.example.com' }))
+      .singleton(),
   });
   await diContainer.loadModules(['./**/*.repository.js'], {
     esModules: true,

--- a/src/container.ts
+++ b/src/container.ts
@@ -2,7 +2,7 @@ import { FastifyInstance } from 'fastify';
 import { diContainer, fastifyAwilixPlugin } from '@fastify/awilix';
 import { asClass, asValue, Lifetime } from 'awilix';
 import prisma from './v1/common/utils/prisma.js';
-import { GotHttpClient } from './v1/common/http/got/http.client.js';
+import { gotClient } from './v1/common/http/got/http.client.js';
 
 export async function setDiContainer(server: FastifyInstance) {
   server.register(fastifyAwilixPlugin, {
@@ -16,9 +16,7 @@ export async function setDiContainer(server: FastifyInstance) {
     jwt: asValue(server.jwt),
     logger: asValue(server.log),
     redisClient: asValue(server.redis),
-    httpClient: asClass(GotHttpClient)
-      .inject(() => ({ baseURL: 'https://api.example.com' }))
-      .singleton(),
+    httpClient: asValue(gotClient),
   });
   await diContainer.loadModules(['./**/*.repository.js'], {
     esModules: true,

--- a/src/v1/apis/auth/auth.service.ts
+++ b/src/v1/apis/auth/auth.service.ts
@@ -12,14 +12,11 @@ import { STATUS } from '../../common/constants/status.js';
 import { NotFoundException } from '../../common/exceptions/core.error.js';
 import { FastifyBaseLogger } from 'fastify';
 import UserRepositoryInterface from '../../storage/database/interfaces/user.repository.interface.js';
-import { HttpClient } from 'src/v1/common/http/interface/http.client.interface.js';
-
 export default class AuthService {
   constructor(
     private readonly userRepository: UserRepositoryInterface,
     private readonly jwt: JWT,
-    private readonly logger: FastifyBaseLogger,
-    private readonly httpClient: HttpClient,
+    private readonly logger: FastifyBaseLogger
   ) {}
 
   async signup(
@@ -34,15 +31,6 @@ export default class AuthService {
     if (!newUser) {
       throw new NotFoundException('User not found');
     }
-
-    // ✅ 테스트용 HTTP 요청
-    const fetchResponse = await this.httpClient.request({
-      url: `http://localhost:3000/users/${newUser.id}`,
-      method: 'GET',
-    });
-
-    console.log('[DEBUG] 외부 요청 응답:', fetchResponse);
-    // ✅ 
 
     this.logger.info(`User ${newUser.id} created successfully`);
     

--- a/src/v1/apis/auth/auth.service.ts
+++ b/src/v1/apis/auth/auth.service.ts
@@ -12,12 +12,14 @@ import { STATUS } from '../../common/constants/status.js';
 import { NotFoundException } from '../../common/exceptions/core.error.js';
 import { FastifyBaseLogger } from 'fastify';
 import UserRepositoryInterface from '../../storage/database/interfaces/user.repository.interface.js';
+import { HttpClient } from 'src/v1/common/http/interface/http.client.interface.js';
 
 export default class AuthService {
   constructor(
     private readonly userRepository: UserRepositoryInterface,
     private readonly jwt: JWT,
     private readonly logger: FastifyBaseLogger,
+    private readonly httpClient: HttpClient,
   ) {}
 
   async signup(
@@ -33,8 +35,17 @@ export default class AuthService {
       throw new NotFoundException('User not found');
     }
 
-    this.logger.info(`User ${newUser.id} created successfully`);
+    // ✅ 테스트용 HTTP 요청
+    const fetchResponse = await this.httpClient.request({
+      url: `http://localhost:3000/users/${newUser.id}`,
+      method: 'GET',
+    });
 
+    console.log('[DEBUG] 외부 요청 응답:', fetchResponse);
+    // ✅ 
+
+    this.logger.info(`User ${newUser.id} created successfully`);
+    
     return {
       status: STATUS.SUCCESS,
       message: 'User information retrieved successfully',
@@ -51,7 +62,6 @@ export default class AuthService {
         message: 'User not found',
       };
     }
-
     return {
       status: STATUS.SUCCESS,
       message: 'User information retrieved successfully',

--- a/src/v1/common/http/got/http.client.ts
+++ b/src/v1/common/http/got/http.client.ts
@@ -1,0 +1,25 @@
+import got from 'got';
+import { HttpClient, HttpRequestOptions } from '../interface/http.client.interface.js';
+
+export class GotHttpClient implements HttpClient {
+  constructor(private baseURL: string) {} // 서버별 다른 주소를 가지나?
+
+  async request(options: HttpRequestOptions): Promise<any> {
+    const { method, url, body, queryParams, headers } = options;
+
+    const client = got.extend({
+      prefixUrl: this.baseURL,
+      responseType: 'json',
+      timeout: { request: 10000 },
+    });
+
+    const response = await client(url, {
+      method,
+      json: body,
+      searchParams: queryParams,
+      headers,
+    });
+
+    return response.body;
+  }
+}

--- a/src/v1/common/http/got/http.client.ts
+++ b/src/v1/common/http/got/http.client.ts
@@ -1,25 +1,20 @@
 import got from 'got';
 import { HttpClient, HttpRequestOptions } from '../interface/http.client.interface.js';
 
-export class GotHttpClient implements HttpClient {
-  constructor(private baseURL: string) {} // 서버별 다른 주소를 가지나?
-
+export const gotClient: HttpClient = {
   async request(options: HttpRequestOptions): Promise<any> {
-    const { method, url, body, queryParams, headers } = options;
-
     const client = got.extend({
-      prefixUrl: this.baseURL,
       responseType: 'json',
       timeout: { request: 10000 },
     });
 
-    const response = await client(url, {
-      method,
-      json: body,
-      searchParams: queryParams,
-      headers,
+    const response = await client(options.url, {
+      method: options.method,
+      json: options.body,
+      searchParams: options.queryParams,
+      headers: options.headers,
     });
 
     return response.body;
   }
-}
+};

--- a/src/v1/common/http/got/http.client.ts
+++ b/src/v1/common/http/got/http.client.ts
@@ -15,6 +15,6 @@ export const gotClient: HttpClient = {
       headers: options.headers,
     });
 
-    return response.body;
+    return response;
   }
 };

--- a/src/v1/common/http/interface/http.client.interface.ts
+++ b/src/v1/common/http/interface/http.client.interface.ts
@@ -1,0 +1,11 @@
+export interface HttpRequestOptions {
+    method: 'GET' | 'POST' | 'PUT' | 'DELETE';
+    url: string;
+    body?: any;
+    queryParams?: Record<string, any>;
+    headers?: Record<string, string>;
+}
+
+export interface HttpClient {
+    request(options: HttpRequestOptions): Promise<any>;
+}

--- a/test/v1/common/http/got/http.client.spec.ts
+++ b/test/v1/common/http/got/http.client.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { HttpClient } from "../../../../../src/v1/common/http/interface/http.client.interface.js";
+import { gotClient } from "../../../../../src/v1/common/http/got/http.client.js";
+
+describe("HTTP Client", () => {
+    it("GET jsonplaceholder.typicode.com", async () => {
+        const httpClient: HttpClient = gotClient;
+
+        const result = await httpClient.request({
+            method: "GET",
+            url: "https://jsonplaceholder.typicode.com/todos/1"
+        });
+        
+        expect(result.body.userId).toBe(1);
+    });
+
+    it("POST jsonplaceholder.typicode.com", async () => {
+        const httpClient: HttpClient = gotClient;
+        
+        const result = await httpClient.request({
+            method: "POST",
+            url: "https://jsonplaceholder.typicode.com/posts",
+            body: {
+                "userId": 1,
+                "id": 3,
+                "title": "jungslee ",
+                "body": "new post"
+            }
+        });
+
+        expect(result.statusCode).toBe(201);
+    });
+
+    it("PUT jsonplaceholder.typicode.com", async () => {
+        const httpClient: HttpClient = gotClient;
+        
+        const result = await httpClient.request({
+            method: "PUT",
+            url: "https://jsonplaceholder.typicode.com/posts/1",
+            body: {
+                "id": 1,
+                "title": 'foo',
+                "body": 'bar',
+                "userId": 1
+            }
+        });
+
+        expect(result.statusCode).toBe(200);
+    });
+
+    it("DELETE jsonplaceholder.typicode.com", async () => {
+        const httpClient: HttpClient = gotClient;
+        
+        const result = await httpClient.request({
+            method: "DELETE",
+            url: "https://jsonplaceholder.typicode.com/posts/1"
+        });
+
+        expect(result.statusCode).toBe(200);
+    });
+});


### PR DESCRIPTION
## 🔗 반영 브랜치

feature/14-서버간-통신-인터페이스-구성 -> main

## 📝 작업 내용

* 서버 통신 클라이언트 상관없이 사용할 수 있는 인터페이스 HttpClient를 추가하였습니다.
* HttpClient의 got 라이브러리를 이용한 구현체 gotClient를 추가하였습니다.
* gotClient의 각각의 요청 (GET, POST, PUT, DELETE) 에 대한 테스트를 추가하였습니다.

## 💬 리뷰 요구사항

> 디렉토리 구조, 이름 혹은 인터페이스 및 함수 이름 같은 부분에 대한 피드백 받고 싶습니다! 
